### PR TITLE
Update the gh dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "node": ">=0.8 <0.12"
     },
     "peerDependencies": {
-        "gh": ">=1.8.0"
+        "gh": ">=1.9"
     },
     "preferGlobal": "true"
 }


### PR DESCRIPTION
When trying to update gh to the new version:

`
npm ERR! peerinvalid The package gh does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer dotfiles@0.5.0 wants gh@~1.8.2
npm ERR! peerinvalid Peer gh-gif@0.1.3 wants gh@>=1.4.0
npm ERR! peerinvalid Peer gh-jira@0.4.3 wants gh@>=1.8.0`
