### PR TITLE
Verify the project only on new tickets or when it is changed with the project flag

### DIFF
--- a/bin/jira.js
+++ b/bin/jira.js
@@ -140,7 +140,7 @@ Jira.getIssueNumber = function(opt_branch, opt_callback) {
                 callback();
                 return;
             }
-            // If project was not found yet, use the last five commit messagesto infer the project name.
+            // If project was not found yet, use the last five commit messages to infer the project name.
             git.getCommitMessage(opt_branch, 5, function(err, data) {
                 project = Jira.getProjectName(Jira.getIssueNumberFromText(data));
                 callback();


### PR DESCRIPTION
It's not mandatory to set the project on updates, if we require it any time we try to update something and we don't pass the project parameter the request will fail.

![](http://cl.ly/image/2B1S3R0g1L0b/Image%202014-03-28%20at%205.13.31%20PM.png)
