### PR TITLE
Only send the reporter parameter on update or when explictly set on the new command

### DIFF
--- a/bin/jira.js
+++ b/bin/jira.js
@@ -140,7 +140,7 @@ Jira.getIssueNumber = function(opt_branch, opt_callback) {
                 callback();
                 return;
             }
-            // If project was not found yet, use the last five commit messagesto infer the project name.
+            // If project was not found yet, use the last five commit messages to infer the project name.
             git.getCommitMessage(opt_branch, 5, function(err, data) {
                 project = Jira.getProjectName(Jira.getIssueNumberFromText(data));
                 callback();

--- a/bin/jira.js
+++ b/bin/jira.js
@@ -695,12 +695,17 @@ Jira.prototype.getUpdatePayload_ = function(opt_callback) {
             });
         },
         function(callback) {
-            instance.getProject_(options.project, function(err, data) {
-                if (!err) {
-                    project = data;
-                }
-                callback(err);
-            });
+            if (!options.new && !options.project) {
+                callback();
+            }
+            else {
+                instance.getProject_(options.project, function(err, data) {
+                    if (!err) {
+                        project = data;
+                    }
+                    callback(err);
+                });
+            }
         },
         function(callback) {
             instance.getProjectComponentByName_(

--- a/bin/jira.js
+++ b/bin/jira.js
@@ -1147,6 +1147,12 @@ Jira.prototype.transition = function(number, name, opt_callback) {
                 ];
             }
 
+            if (options.assignee) {
+                payload.fields.assignee = {
+                    name: options.assignee
+                };
+            }
+
             instance.expandTransitionFields_(transitionConfig, transition, payload, function(err, data) {
                 if (!err) {
                     payload = data;

--- a/bin/jira.js
+++ b/bin/jira.js
@@ -220,7 +220,6 @@ Jira.prototype.run = function() {
 
     options.originalAssignee = options.assignee;
     options.assignee = options.assignee || jiraConfig.user;
-    options.reporter = options.reporter || jiraConfig.user;
 
     operations = [
         function(callback) {
@@ -502,6 +501,9 @@ Jira.prototype.encryptText_ = function(text) {
 Jira.prototype.expandAliases_ = function(options) {
     if (config.alias) {
         options.assignee = config.alias[options.assignee] || options.assignee;
+    }
+
+    if (options.new && config.alias) {
         options.reporter = config.alias[options.reporter] || options.reporter;
     }
 };
@@ -773,9 +775,6 @@ Jira.prototype.getUpdatePayload_ = function(opt_callback) {
                     project: {
                         id: project.id
                     },
-                    reporter: {
-                        name: options.reporter
-                    },
                     summary: options.title
                 }
             };
@@ -792,6 +791,12 @@ Jira.prototype.getUpdatePayload_ = function(opt_callback) {
                         id: version.id
                     }
                 ];
+            }
+
+            if (options.reporter && (!options.new || options.reporter !== jiraConfig.user)) {
+                payload.fields.reporter = {
+                    name: options.reporter
+                };
             }
 
             callback();

--- a/bin/jira.js
+++ b/bin/jira.js
@@ -81,7 +81,7 @@ Jira.DETAILS = {
     }
 };
 
-Jira.ACTION_ISSUE_ASSIGN_TO_ME = 'ISSUE_ASSIGN_TO_ME';
+Jira.ACTION_ISSUE_ASSIGN = 'ISSUE_ASSIGN';
 
 Jira.ACTION_ISSUE_OPEN_IN_BROWSER = 'ISSUE_OPEN_IN_BROWSER';
 
@@ -1220,10 +1220,16 @@ Jira.prototype.transitionWithQuestion_ = function(number, name, opt_callback) {
                 ], function(answers) {
                     switch (answers.transition) {
                         case 'Assign to me':
-                            action = Jira.ACTION_ISSUE_ASSIGN_TO_ME;
+                            action = Jira.ACTION_ISSUE_ASSIGN;
+                            options.assignee = jiraConfig.user;
                             break;
                         case 'Open in browser':
                             action = Jira.ACTION_ISSUE_OPEN_IN_BROWSER;
+                            break;
+                        case 'Nothing, thanks':
+                            if (options.assignee) {
+                                action = Jira.ACTION_ISSUE_ASSIGN;
+                            }
                             break;
                         default:
                             action = instance.findFirstArrayValue_(
@@ -1240,13 +1246,11 @@ Jira.prototype.transitionWithQuestion_ = function(number, name, opt_callback) {
                 return;
             }
 
-            if (action === Jira.ACTION_ISSUE_ASSIGN_TO_ME) {
+            if (action === Jira.ACTION_ISSUE_ASSIGN) {
                 logger.logTemplate(
-                    '{{prefix}} [info] Assigning issue to {{magentaBright jira.user}}', {
-                        jira: jiraConfig
+                    '{{prefix}} [info] Assigning issue to {{magentaBright options.assignee}}', {
+                        options: options
                     });
-
-                options.assignee = jiraConfig.user;
 
                 instance.update(options.number, function(err, issue) {
                     response = issue;


### PR DESCRIPTION
Some JIRA installations doesn't allow the reporter parameter to be set this way.

```
$ gh jira -N --type Bug --project AUI --component JavaScript
gh [info] Creating a new issue on project AUI
gh [error] { reporter: 'Field \'reporter\' cannot be set. It is not on the appropriate screen, or unknown.' }
```