### PR TITLE
add info about how to run and setup host.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,32 @@ NodeGH plugin for integrating [Jira](https://www.atlassian.com/software/jira), a
 
 ## Usage
 
+Note: Run the following *inside* a git repository as otherwise it will show
+an error.
+
 ```
 gh jira
 ```
 
 > **Alias:** `gh ji`
+
+On first run it will ask for your jira 'username' and 'password'.
+This will create `~/.gh.json` and then fail because it does not yet
+know your jira server.
+
+To fix this edit `~/.gh.json` and add a `host` to the `jira` section
+so you will get something like the following:
+
+```
+    "plugins": {
+        "jira": {
+	    "host": "issues.jboss.org",
+            "user": "maxandersen",
+            "password": "secrethash"
+        }
+    },
+
+```
 
 ### 1. Create
 


### PR DESCRIPTION
Related to #48 

The current defaults will not ask user about the host server
thus it will not configured automatically.

Furthermore running `gh jira` outside a git repository gives errors.

Added docs about these to readme.md until fixed better.