### PR TITLE
Add a link to the JIRA comment pointing to the pull request being reviewed

### DIFF
--- a/gh-plugin.json
+++ b/gh-plugin.json
@@ -11,7 +11,7 @@
             "fetch": {
                 "before": [],
                 "after": [
-                    "{{#if jira.number.current}} gh jira {{jira.number.current}} --comment 'Just started reviewing :)' {{/if}}"
+                    "{{#if jira.number.current}} gh jira {{jira.number.current}}  --comment 'Just started reviewing [{{options.user}}/{{options.repo}}#{{options.number}}|https://github.com/{{options.user}}/{{options.repo}}/pull/{{options.number}}].' {{/if}}"
                 ]
             },
             "fwd": {


### PR DESCRIPTION
Hey all.

Often I receive many pull requests to the same ticket, or get to review the same one more than once. The result is that there will be many comments but nothing about what I'm reviewing:

![Two comments about two reviews, but I do not know which pull request is being reviewed.](http://i.imgur.com/YxIrhej.png)

So I changed my `.gh.json` to link to the pull request. Since it can be useful to many people, I'm submitting the fix.

Thanks!