### PR TITLE
Match issue number for project ids with 2 letters

### DIFF
--- a/bin/jira.js
+++ b/bin/jira.js
@@ -72,7 +72,7 @@ class Jira {
 
         // Try uppercase sequence first, e.g. FOO-123.
         // If not found, try case-insensitive sequence, e.g. foo-123.
-        let match = text.match(/[A-Z]{3,}-\d+/) || text.match(/[a-z]{3,}-\d+/i);
+        let match = text.match(/[A-Z]{2,}-\d+/) || text.match(/[a-z]{2,}-\d+/i);
 
         if (match) {
             return match[0].toUpperCase();


### PR DESCRIPTION
Currently this only matches for 3, but some projects have only 2 characters.

In the [Jira docs](https://confluence.atlassian.com/adminjiraserver075/changing-the-project-key-format-935391077.html) it also states:

> **By default, the JIRA project key configuration requires two or more uppercase alphabetical characters** — based on the regular expression ([A-Z][A-Z]+).