### PR TITLE
Send for review node gh jira integration

### DIFF
--- a/gh-plugin.json
+++ b/gh-plugin.json
@@ -10,9 +10,7 @@
             },
             "fetch": {
                 "before": [],
-                "after": [
-                    "{{#if jira.number.current}} gh jira {{jira.number.current}}  --comment 'Just started reviewing [{{options.user}}/{{options.repo}}#{{options.number}}|https://github.com/{{options.user}}/{{options.repo}}/pull/{{options.number}}].' {{/if}}"
-                ]
+                "after": []
             },
             "fwd": {
                 "before": [],
@@ -49,6 +47,12 @@
             "Git Pull Request": "{{options.submittedLink}}"
         },
         "Create Review Request": {
+            "Assignee": {
+                "name": "{{options.assignee}}"
+            },
+            "Git Pull Request": "{{options.submittedLink}}"
+        },
+        "Send for Review": {
             "Assignee": {
                 "name": "{{options.assignee}}"
             },


### PR DESCRIPTION
Hey @henvic, This fixes the jira transition send for review after sending a pr with node-gh.  Once sent it will open up the transition interface and automatically transition to the correct person and specify the correct url. Thanks